### PR TITLE
Support the Johns Hopkins COVID Data and Vaccine Data

### DIFF
--- a/CovidSharp/CdcVaccine/Models/VaccineState.cs
+++ b/CovidSharp/CdcVaccine/Models/VaccineState.cs
@@ -24,6 +24,9 @@ namespace CovidSharp.CdcVaccine.Models
         public int DosesAdministered { get; set; }
         public int DistributedPer100K { get; set; }
         public int AdministeredPer100K { get; set; }
+        public double PercentAdultVaccinated { get; set; }
+        public double PercentSeniorsVaccinated { get; set; }
+
 
         public VaccineDay(VaccineStateDay vsd)
         {
@@ -32,6 +35,12 @@ namespace CovidSharp.CdcVaccine.Models
             DosesAdministered = vsd.DosesAdministered;
             DistributedPer100K = vsd.DistributedPer100K;
             AdministeredPer100K = vsd.AdministeredPer100K;
+            PercentAdultVaccinated = 0;
+            PercentSeniorsVaccinated = 0;
+            if(vsd.Dose1Admin18PlusPct.HasValue)
+                PercentAdultVaccinated = vsd.Dose1Admin18PlusPct.Value;
+            if(vsd.Dose1Admin65PlusPct.HasValue)
+                PercentSeniorsVaccinated = vsd.Dose1Admin65PlusPct.Value; 
         }
     }
 }

--- a/CovidSharp/CdcVaccine/Models/VaccineStateDay.cs
+++ b/CovidSharp/CdcVaccine/Models/VaccineStateDay.cs
@@ -42,6 +42,9 @@ namespace CovidSharp.CdcVaccine
         [JsonProperty("LongName")]
         public string StateName { get; set; }
 
+        [JsonProperty("Census2019")]
+        public int StatePopulation { get; set; }
+
         [JsonProperty("Doses_Distributed")]
         public int DosesDistributed { get; set; }
 
@@ -54,19 +57,81 @@ namespace CovidSharp.CdcVaccine
         [JsonProperty("Admin_Per_100K")]
         public int AdministeredPer100K { get; set; }
 
-        [JsonProperty("Census2019")]
-        public int StatePopulation { get; set; }
+        // The CDC started tracking dose numbers on the 12th
+        [JsonProperty("Administered_Dose1")]
+        public int? Dose1Administered { get; set; }
 
+        [JsonProperty("Administered_Dose1_Per_100K")]
+        public int? Dose1AdministeredPer100K { get; set; }
+
+        [JsonProperty("Administered_Dose2")]
+        public int? Dose2Administered { get; set; }
+
+        [JsonProperty("Administered_Dose2_Per_100K")]
+        public int? Dose2AdministeredPer100K { get; set; }
+
+        // The CDC Tracked manifacturing for about 5 days
         [JsonProperty("Administered_Moderna")]
         public int? DosesAdministeredModerna { get; set; }
-
+        
         [JsonProperty("Administered_Pfizer")]
         public int? DosesAdministeredPfizer { get; set; }
+
+        [JsonProperty("Administered_Janssen")]
+        public int? DosesAdministeredJanssen { get; set; }
 
         [JsonProperty("Administered_Unk_Manuf")]
         public int? DosesAdministeredUnknown { get; set; }
 
         [JsonProperty("Ratio_Admin_Dist")]
         public double? DistributedAdminRatio { get; set; }
+
+        [JsonProperty("Administered_Dose1_Pop_Pct")]
+        public double? Dose1AdminPopulationPct { get; set; }
+        
+        [JsonProperty("Administered_Dose2_Pop_Pct")]
+        public double? Dose2AdminPopulationPct { get; set; }
+        
+        [JsonProperty("Administered_Dose1_Recip_18Plus")]
+        public int? Dose1Admin18Plus { get; set; }
+        
+        [JsonProperty("Administered_Dose1_Recip_18PlusPop_Pct")]
+        public double? Dose1Admin18PlusPct { get; set; }
+        
+        [JsonProperty("Administered_18Plus")]
+        public int? Admin18Plus { get; set; }
+        
+        [JsonProperty("Administered_Dose1_Recip_65Plus")]
+        public int? Dose1Admin65Plus { get; set; }
+        
+        [JsonProperty("Administered_Dose1_Recip_65PlusPop_Pct")]
+        public double? Dose1Admin65PlusPct { get; set; }
+        
+        [JsonProperty("Administered_65Plus")]
+        public int? Admin65Plus { get; set; }
+        
+        [JsonProperty("Administered_Dose2_Recip")]
+        public int? Dose2Admin { get; set; }
+        
+        [JsonProperty("Administered_Dose2_Recip_18Plus")]
+        public int? Dose2Admin18Plus { get; set; }
+        
+        [JsonProperty("Administered_Dose2_Recip_18PlusPop_Pct")]
+        public double? Dose2Admin18PlusPct { get; set; }
+        
+        [JsonProperty("Series_Complete_Pop_Pct")]
+        public double? SeriesCompletePopPct { get; set; }
+        
+        [JsonProperty("Series_Complete_18Plus")]
+        public int? SeriesComplete18Plus { get; set; }
+        
+        [JsonProperty("Series_Complete_18PlusPop_Pct")]
+        public double? SeriesComplete18PlusPct { get; set; }
+        
+        [JsonProperty("Series_Complete_65Plus")]
+        public int? SeriesComplete65Plus { get; set; }
+
+        [JsonProperty("Series_Complete_65PlusPop_Pct")]
+        public double? SeriesComplete65PlusPct { get; set; }
     }
 }

--- a/CovidSharp/CovidSharp.csproj
+++ b/CovidSharp/CovidSharp.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="CsvHelper" Version="25.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 

--- a/CovidSharp/CovidTrack/CovidTrackingConfig.cs
+++ b/CovidSharp/CovidTrack/CovidTrackingConfig.cs
@@ -63,5 +63,6 @@ namespace CovidSharp.CovidTrack
         #endregion 
         
         private const string dateSub = "{date}";
+
     }
 }

--- a/CovidSharp/HhsHospitals/HhsHospitals.cs
+++ b/CovidSharp/HhsHospitals/HhsHospitals.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace CovidSharp.HhsHospitals
+{
+    public class HhsHospitals
+    {
+        //https://healthdata.gov/sites/default/files/reported_hospital_utilization_20210303_2306.csv
+    }
+}

--- a/CovidSharp/JohnsHopkins/Model/JhStateDay.cs
+++ b/CovidSharp/JohnsHopkins/Model/JhStateDay.cs
@@ -1,0 +1,70 @@
+﻿using CovidSharp.Constants;
+using CovidSharp.Models;
+using CovidSharp.Utils;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace CovidSharp.JohnsHopkins.Model
+{
+    public class JhState
+    {
+        public StateBase State { get; set; }
+        public string StateString { get; set; }
+        public List<JhCovidDay> CovidData { get; set; }
+
+        public JhState(string stateName) {
+            State = StateMapHelper.StringToStateMap(stateName);
+            StateString = stateName;
+            CovidData = new List<JhCovidDay>();
+        }
+    }
+
+    public class JhCovidDay
+    {
+        public JhCovidDay() { }
+
+        public JhCovidDay(RawJhState rawData, string filePath)
+        {
+            int month = Int32.TryParse(filePath.Substring(0, 2), out int m) ? m : 1;
+            int day = Int32.TryParse(filePath.Substring(3, 2), out int d) ? d : 1;
+            int year = Int32.TryParse(filePath.Substring(6, 4), out int y) ? y : 1;
+            Date = new DateTime(year, month, day);
+            Positives = rawData.Confirmed;
+            Deaths = rawData.Deaths;
+            Recovered = rawData.Recovered;
+            Active = rawData.Active;
+            Tests = rawData.People_Tested;
+        }
+
+        public DateTime Date { get; set; }
+        public double Positives { get; set; }
+        public double Deaths { get; set; }
+        public double Recovered { get; set; }
+        public double Active { get; set; }
+        public double Tests { get; set; }
+    }
+
+    public class RawJhState
+    {
+        public string Province_State { get; set; }
+        public string Country_Region { get; set; }
+        public string Last_Update { get; set; }
+        public double Lat { get; set; }
+        public double Long_ { get; set; }
+        public int Confirmed { get; set; }
+        public int Deaths { get; set; }
+        public int Recovered { get; set; }
+        public int Active { get; set; }
+        public int FIPS { get; set; }
+        public double Incident_Rate { get; set; }
+        public int People_Tested { get; set; }
+        public int People_Hospitalized { get; set; }
+        public double Mortality_Rate { get; set; }
+        public int UID { get; set; }
+        public string ISO3 { get; set; }
+        public double Testing_Rate { get; set; }
+        public double Hospitalization_Rate { get; set; }
+    }
+
+}

--- a/CovidSharp/Utils/StringToStateMap.cs
+++ b/CovidSharp/Utils/StringToStateMap.cs
@@ -1,0 +1,291 @@
+﻿using CovidSharp.Constants;
+using CovidSharp.Models;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+
+namespace CovidSharp.Utils
+{
+    public static class StateMapHelper {
+        public static StateBase StringToStateMap(string stateString)
+        {
+            var listOfStates = StatesConstants.GetStatesList();
+            switch (stateString.ToLower())
+            {
+                case "alabama":
+                case "al":
+                    return listOfStates.FirstOrDefault(s => s.Code == Constants.StateCode.AL);
+                case "alaska":
+                case "ak":
+                    return listOfStates.FirstOrDefault(s => s.Code == Constants.StateCode.AK);
+                case "american samoa":
+                case "americansamoa":
+                case "as":
+                    return listOfStates.FirstOrDefault(s => s.Code == Constants.StateCode.AS);
+                case "arizona":
+                case "az":
+                    return listOfStates.FirstOrDefault(s => s.Code == Constants.StateCode.AZ);
+                case "arkansas":
+                case "ar":
+                    return listOfStates.FirstOrDefault(s => s.Code == Constants.StateCode.AR);
+                case "california":
+                case "ca":
+                    return listOfStates.FirstOrDefault(s => s.Code == Constants.StateCode.CA);
+                case "colorado":
+                case "co":
+                    return listOfStates.FirstOrDefault(s => s.Code == Constants.StateCode.CO);
+                case "connecticut":
+                case "ct":
+                    return listOfStates.FirstOrDefault(s => s.Code == Constants.StateCode.CT);
+                case "delaware":
+                case "de":
+                    return listOfStates.FirstOrDefault(s => s.Code == Constants.StateCode.DE);
+                case "districtofcolumbia":
+                case "district of columbia":
+                case "washingtondc":
+                case "dc":
+                    return listOfStates.FirstOrDefault(s => s.Code == Constants.StateCode.DC);
+                case "florida":
+                case "fl":
+                    return listOfStates.FirstOrDefault(s => s.Code == Constants.StateCode.FL);
+                case "georgia":
+                case "ga":
+                    return listOfStates.FirstOrDefault(s => s.Code == Constants.StateCode.GA);
+                case "guam":
+                case "gu":
+                    return listOfStates.FirstOrDefault(s => s.Code == Constants.StateCode.GU);
+                case "hawaii":
+                case "hi":
+                    return listOfStates.FirstOrDefault(s => s.Code == Constants.StateCode.HI);
+                case "idaho":
+                case "id":
+                    return listOfStates.FirstOrDefault(s => s.Code == Constants.StateCode.ID);
+                case "illinois":
+                case "il":
+                    return listOfStates.FirstOrDefault(s => s.Code == Constants.StateCode.IL);
+                case "indiana":
+                case "in":
+                    return listOfStates.FirstOrDefault(s => s.Code == Constants.StateCode.IN);
+                case "iowa":
+                case "ia":
+                    return listOfStates.FirstOrDefault(s => s.Code == Constants.StateCode.IA);
+                case "kansas":
+                case "ks":
+                    return listOfStates.FirstOrDefault(s => s.Code == Constants.StateCode.KS);
+                case "kentucky":
+                case "ky":
+                    return listOfStates.FirstOrDefault(s => s.Code == Constants.StateCode.KY);
+                case "louisiana":
+                case "la":
+                    return listOfStates.FirstOrDefault(s => s.Code == Constants.StateCode.LA);
+                case "maine":
+                case "me":
+                    return listOfStates.FirstOrDefault(s => s.Code == Constants.StateCode.ME);
+                case "maryland":
+                case "md":
+                    return listOfStates.FirstOrDefault(s => s.Code == Constants.StateCode.MD);
+                case "massachusetts":
+                case "ma":
+                    return listOfStates.FirstOrDefault(s => s.Code == Constants.StateCode.MA);
+                case "michigan":
+                case "mi":
+                    return listOfStates.FirstOrDefault(s => s.Code == Constants.StateCode.MI);
+                case "minnesota":
+                case "mn":
+                    return listOfStates.FirstOrDefault(s => s.Code == Constants.StateCode.MN);
+                case "mississippi":
+                case "ms":
+                    return listOfStates.FirstOrDefault(s => s.Code == Constants.StateCode.MS);
+                case "missouri":
+                case "mo":
+                    return listOfStates.FirstOrDefault(s => s.Code == Constants.StateCode.MO);
+                case "montana":
+                case "mt":
+                    return listOfStates.FirstOrDefault(s => s.Code == Constants.StateCode.MT);
+                case "nebraska":
+                case "ne":
+                    return listOfStates.FirstOrDefault(s => s.Code == Constants.StateCode.NE);
+                case "nevada":
+                case "nv":
+                    return listOfStates.FirstOrDefault(s => s.Code == Constants.StateCode.NV);
+                case "new hampshire":
+                case "newhampshire":
+                case "nh":
+                    return listOfStates.FirstOrDefault(s => s.Code == Constants.StateCode.NH);
+                case "new jersey":
+                case "newjersey":
+                case "nj":
+                    return listOfStates.FirstOrDefault(s => s.Code == Constants.StateCode.NJ);
+                case "new mexico":
+                case "newmexico":
+                case "nm":
+                    return listOfStates.FirstOrDefault(s => s.Code == Constants.StateCode.NM);
+                case "new york":
+                case "newyork":
+                case "ny":
+                    return listOfStates.FirstOrDefault(s => s.Code == Constants.StateCode.NY);
+                case "north carolina":
+                case "northcarolina":
+                case "nc":
+                    return listOfStates.FirstOrDefault(s => s.Code == Constants.StateCode.NC);
+                case "north dakota":
+                case "northdakota":
+                case "nd":
+                    return listOfStates.FirstOrDefault(s => s.Code == Constants.StateCode.ND);
+                case "ohio":
+                case "oh":
+                    return listOfStates.FirstOrDefault(s => s.Code == Constants.StateCode.OH);
+                case "oklahoma":
+                case "ok":
+                    return listOfStates.FirstOrDefault(s => s.Code == Constants.StateCode.OK);
+                case "oregon":
+                case "or":
+                    return listOfStates.FirstOrDefault(s => s.Code == Constants.StateCode.OR);
+                case "pennsylvania":
+                case "pa":
+                    return listOfStates.FirstOrDefault(s => s.Code == Constants.StateCode.PA);
+                case "puerto rico":
+                case "puertorico":
+                case "pr":
+                    return listOfStates.FirstOrDefault(s => s.Code == Constants.StateCode.PR);
+                case "rhode island":
+                case "rhodeisland":
+                case "ri":
+                    return listOfStates.FirstOrDefault(s => s.Code == Constants.StateCode.RI);
+                case "south carolina":
+                case "southcarolina":
+                case "sc":
+                    return listOfStates.FirstOrDefault(s => s.Code == Constants.StateCode.SC);
+                case "south dakota":
+                case "southdakota":
+                case "sd":
+                    return listOfStates.FirstOrDefault(s => s.Code == Constants.StateCode.SD);
+                case "tennessee":
+                case "tn":
+                    return listOfStates.FirstOrDefault(s => s.Code == Constants.StateCode.TN);
+                case "texas":
+                case "tx":
+                    return listOfStates.FirstOrDefault(s => s.Code == Constants.StateCode.TX);
+                case "utah":
+                case "ut":
+                    return listOfStates.FirstOrDefault(s => s.Code == Constants.StateCode.UT);
+                case "vermont":
+                case "vt":
+                    return listOfStates.FirstOrDefault(s => s.Code == Constants.StateCode.VT);
+                case "virgin islands":
+                case "virginislands":
+                case "vi":
+                    return listOfStates.FirstOrDefault(s => s.Code == Constants.StateCode.VI);
+                case "virginia":
+                case "va":
+                    return listOfStates.FirstOrDefault(s => s.Code == Constants.StateCode.VA);
+                case "washington":
+                case "wa":
+                    return listOfStates.FirstOrDefault(s => s.Code == Constants.StateCode.WA);
+                case "west virginia":
+                case "westvirginia":
+                case "wv":
+                    return listOfStates.FirstOrDefault(s => s.Code == Constants.StateCode.WV);
+                case "wisconsin":
+                case "wi":
+                    return listOfStates.FirstOrDefault(s => s.Code == Constants.StateCode.WI);
+                case "wyoming":
+                case "wy":
+                    return listOfStates.FirstOrDefault(s => s.Code == Constants.StateCode.WY);
+                default:
+                    Debug.WriteLine("Bad State - " + stateString.ToLower());
+                    return null;
+            }
+        }
+
+        public static bool LooseStateStringMatch(string stateString, string aliasString)
+        {
+            var l1 = stateString.ToLower();
+            var l2 = stateString.ToLower();
+            if (stateString.ToLower() == aliasString.ToLower())
+                return true;
+            else
+            {
+                if ((l1 == "american samoa" || l1 == "americansamoa") && (l2 == "american samoa" || l2 == "americansamoa")) return true;
+
+                if ((l1 == "districtofcolumbia" || l1 == "district of columbia" || l1 == "washingtondc") && 
+                    (l2 == "districtofcolumbia" || l2 == "district of columbia" || l1 == "washingtondc")) return true;
+
+                if ((l1 == "west virginia" || l1 == "westvirginia") &&
+                    (l2 == "west virginia" || l2 == "westvirginia")) return true;
+
+                if ((l1 == "virgin islands" || l1 == "virginislands") &&
+                    (l2 == "virgin islands" || l2 == "virginislands")) return true;
+
+                if ((l1 == "puerto rico" || l1 == "puertorico") &&
+                    (l2 == "puerto rico" || l2 == "puertorico")) return true;
+
+                if ((l1 == "rhode island" || l1 == "rhodeisland") &&
+                    (l2 == "rhode island" || l2 == "rhodeisland")) return true;
+
+                if ((l1 == "south carolina" || l1 == "southcarolina") &&
+                    (l2 == "south carolina" || l2 == "southcarolina")) return true;
+
+                if ((l1 == "south dakota" || l1 == "southdakota") &&
+                    (l2 == "south dakota" || l2 == "southdakota")) return true;
+
+                if ((l1 == "new hampshire" || l1 == "newhampshire") &&
+                    (l2 == "new hampshire" || l2 == "newhampshire")) return true;
+
+                if ((l1 == "new jersey" || l1 == "newjersey") &&
+                    (l2 == "new jersey" || l2 == "newjersey")) return true;
+
+                if ((l1 == "new mexico" || l1 == "newmexico") &&
+                    (l2 == "new mexico" || l2 == "newmexico")) return true;
+
+                if ((l1 == "new york" || l1 == "newyork") &&
+                    (l2 == "new york" || l2 == "newyork")) return true;
+
+                if ((l1 == "north carolina" || l1 == "northcarolina") &&
+                    (l2 == "north carolina" || l2 == "northcarolina")) return true;
+
+                if ((l1 == "north dakota" || l1 == "northdakota") &&
+                    (l2 == "north dakota" || l2 == "northdakota")) return true;
+                
+                return false;
+            }
+        }
+    
+        public static string StateBaseToString(StateName sn)
+        {
+            switch (sn)
+            {
+                case StateName.AmericanSamoa:
+                    return "American Samoa";
+                case StateName.MarianaIslands:
+                    return "Norther Mariana Islands"; 
+                case StateName.WashingtonDC:
+                    return "District of Columbia";
+                case StateName.NewHampshire:
+                    return "New Hampshire";
+                case StateName.NewJersey:
+                    return "New Jersey";
+                case StateName.NewMexico:
+                    return "New Mexico";
+                case StateName.NewYork:
+                    return "New York";
+                case StateName.NorthCarolina:
+                    return "North Carolina";
+                case StateName.NorthDakota:
+                    return "North Dakota";
+                case StateName.RhodeIsland:
+                    return "Rhode Island";
+                case StateName.SouthCarolina:
+                    return "South Carolina";
+                case StateName.SouthDakota:
+                    return "South Dakota";
+                case StateName.WestVirginia:
+                    return "West Virginia";
+                default:
+                    return sn.ToString();
+            }
+        }
+    }
+}


### PR DESCRIPTION
I wrote about the shift from using COVID Tracking Project numbers to the Johns Hopkins data here

https://polimath.substack.com/p/revaluating-my-covid-data-strategy  